### PR TITLE
feat: add custom nu config support via CLI args

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,14 @@ Example good commit messages from this project:
 
 Always run `./scripts/check.sh` before committing. Use `cargo fmt` to fix formatting issues.
 
+## Release Process
+
+1. Find last stable release: `git tag --sort=-version:refname | grep -v dev | head -1`
+2. Get commits since last release: `git log --oneline --pretty=format:"* %s (%ad)" --date=short v{last}..HEAD`
+3. Create `changes/v{version}.md` with title and commit list
+4. Add highlights section for notable changes
+5. Commit changes and tag: `git tag v{version}`
+
 ## Version Bump Process
 
 When bumping version:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 # MCP Server Nu
 
-MCP server for executing Nushell scripts.
+An MCP (Model Context Protocol) server that allows AI assistants to execute
+Nushell scripts with full system access.
 
 <img width="745" height="687" alt="image" src="https://github.com/user-attachments/assets/7df465b7-cbaf-47a2-9fa1-a2ab9c1f0fb3" />
 
-⚠️ **No safety mechanisms. Do not use in production.**
+## How it works
+
+This server spawns `nu -c "<script>"` processes to execute commands. The nu
+process runs with the same permissions as the server process, giving it access
+to:
+
+- File system (read/write/delete)
+- Network (make requests, start servers)
+- Environment variables
+- System commands via nu's shell integration
+- Any custom nu configurations you provide
+
+**Security implications**: The AI can execute arbitrary code on your system.
+Only use with trusted AI assistants and in environments where this level of
+access is acceptable.
 
 ## Tool: exec
 
@@ -24,9 +39,31 @@ Executes Nushell scripts and returns stdout, stderr, exit code.
 }
 ```
 
+## Configuration
+
+The server accepts optional CLI arguments to use custom nu config files:
+
+```bash
+mcp-server-nu --nu-config /path/to/config.nu --nu-env-config /path/to/env.nu
+```
+
+**Options:**
+
+- `--nu-config <path>`: Custom config.nu file (sets up commands, aliases, etc.)
+- `--nu-env-config <path>`: Custom env.nu file (sets up environment variables)
+
+When provided, these configs are loaded for every script execution via
+`nu --config <path> --env-config <path> -c "<script>"`.
+
 ## Install & Test
 
 ```bash
 cargo install --locked mcp-server-nu
 npx @modelcontextprotocol/inspector mcp-server-nu
+```
+
+**With custom config:**
+
+```bash
+npx @modelcontextprotocol/inspector -- mcp-server-nu --nu-config /path/to/config.nu
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,19 @@ use tools::NuServer;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
-struct Args {}
+struct Args {
+    /// Path to custom nushell config.nu file
+    #[arg(long = "nu-config")]
+    nu_config: Option<String>,
+
+    /// Path to custom nushell env.nu file
+    #[arg(long = "nu-env-config")]
+    nu_env_config: Option<String>,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let _args = Args::parse();
+    let args = Args::parse();
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -22,7 +30,10 @@ async fn main() -> Result<()> {
 
     // Create and start the Nushell MCP server
     loop {
-        match NuServer::new().serve(stdio()).await {
+        match NuServer::new(args.nu_config.clone(), args.nu_env_config.clone())
+            .serve(stdio())
+            .await
+        {
             Ok(service) => {
                 service.waiting().await?;
                 break;

--- a/tests/fixtures/nushell/config.nu
+++ b/tests/fixtures/nushell/config.nu
@@ -1,0 +1,10 @@
+# Test fixture config for mcp-server-nu integration tests
+$env.TEST_CONFIG_LOADED = "yes"
+
+# Custom command for testing
+def test_custom_cmd [] {
+  "custom command works"
+}
+
+# Set table mode for testing
+$env.config.table.mode = "light"

--- a/tests/fixtures/nushell/env.nu
+++ b/tests/fixtures/nushell/env.nu
@@ -1,0 +1,3 @@
+# Test fixture environment config for mcp-server-nu integration tests
+$env.TEST_ENV_LOADED = "yes"
+$env.CUSTOM_PATH = "/test/path"


### PR DESCRIPTION
Adds CLI args `--nu-config` and `--nu-env-config` to use custom nushell configuration files.

When provided, all exec tool calls use `nu --config <path> --env-config <path> -c "<script>"` instead of plain `nu -c "<script>"`.

Enables users to provide custom commands, aliases, and environment variables for AI script execution.